### PR TITLE
fix: avoid pnpm version check in bootstrap

### DIFF
--- a/scripts/src/shared/git.ts
+++ b/scripts/src/shared/git.ts
@@ -93,7 +93,7 @@ export async function cloneRepo(productName: string, caseName: string) {
   );
 
   // run prepare before linking cases
-  await runCommand(localRepoPath, 'corepack enable && pnpm -v');
+  await runCommand(localRepoPath, 'corepack enable');
   await runCommand(localRepoPath, 'pnpm i --ignore-scripts');
   await runCommand(localRepoPath, 'pnpm prepare');
 


### PR DESCRIPTION
## What changed

This removes the `pnpm -v` check from the Rspress bootstrap path in the benchmark scripts and keeps only `corepack enable` before install/prepare.

## Why

`pnpm -v` is expected to be a fast no-op version check, but on newer Rspress commits it can hang after printing the version and block the benchmark flow before dependency installation starts.

## Impact

Running the Rspress benchmark no longer stalls at the pre-install bootstrap step.

## Root cause

The benchmark script awaited `corepack enable && pnpm -v` before install. In affected Rspress revisions, the nested `pnpm -v` call does not exit cleanly, so the script never advances to `pnpm i --ignore-scripts`.

## Validation

- `pnpm run build` in `scripts`
