### PR TITLE
fix: rsbuild-arco-pro husky install failure

### DIFF
--- a/cases/rsbuild/rsbuild-arco-pro/package.json
+++ b/cases/rsbuild/rsbuild-arco-pro/package.json
@@ -39,7 +39,6 @@
     "rimraf": "^3.0.2",
     "lint-staged": "^11.2.6",
     "prettier": "^2.8.8",
-    "husky": "4.3.8",
     "typescript": "^5.9.3",
     "@types/react": "^18.3.28",
     "@types/react-dom": "^18.3.7",


### PR DESCRIPTION
## Summary

- Remove `husky@4.3.8` from the `rsbuild-arco-pro` benchmark case devDependencies.
- Avoid triggering pnpm's ignored-builds failure when the case is copied into the Rsbuild workspace during scheduled benchmarks.

## Root Cause

The scheduled `benchmark (rsbuild-arco-pro, RSBUILD)` job failed in `pnpm i --force --no-frozen-lockfile` with `ERR_PNPM_IGNORED_BUILDS` because `husky@4.3.8` has a build script and is not approved by the Rsbuild workspace strict build policy. The case does not use Husky scripts, so the dependency can be removed.

Failing job: https://github.com/web-infra-dev/web-infra-QoS/actions/runs/25757331530/job/75649129183

## Validation

- `pnpm --filter @modern-js/benchmark-scripts run build`
- In the local Rsbuild checkout with the updated case: `pnpm i --force --no-frozen-lockfile`