### PR TITLE
fix: build rsbuild and rslib repos before benchmark

### DIFF
--- a/scripts/src/shared/git.ts
+++ b/scripts/src/shared/git.ts
@@ -97,6 +97,10 @@ export async function cloneRepo(productName: string, caseName: string) {
   await runCommand(localRepoPath, 'pnpm i --ignore-scripts');
   await runCommand(localRepoPath, 'pnpm prepare');
 
+  if (productName === 'RSBUILD' || productName === 'RSLIB') {
+    await runCommand(localRepoPath, 'pnpm build');
+  }
+
   // add cases folder to workspace config
   await updateFile(join(localRepoPath, 'pnpm-workspace.yaml'), content =>
     addContentToPnpmPackages(content, "- 'cases/*'"),


### PR DESCRIPTION
This PR fixes benchmark setup for Rsbuild and Rslib cases. These cases rely on workspace packages from the cloned product repositories, and those repositories now need a manual repository build after install/prepare so package outputs exist before the benchmark case build runs.

Validation:
- `pnpm --filter @modern-js/benchmark-scripts run build`