### PR TITLE
fix: resolve rslib workspace peer dependency

### DIFF
--- a/scripts/src/shared/git.ts
+++ b/scripts/src/shared/git.ts
@@ -106,6 +106,16 @@ export async function cloneRepo(productName: string, caseName: string) {
     addContentToPnpmPackages(content, "- 'cases/*'"),
   );
 
+  if (productName === 'RSLIB') {
+    await updateFile(join(localRepoPath, 'package.json'), content => {
+      const packageJson = JSON.parse(content);
+      packageJson.devDependencies ??= {};
+      packageJson.devDependencies['@rslib/core'] = 'workspace:*';
+
+      return `${JSON.stringify(packageJson, null, 2)}\n`;
+    });
+  }
+
   // rename prepare scripts to avoid executing
   // pnpm link will execute complete process of pnpm install in pnpm v10.
   await updateFile(


### PR DESCRIPTION
## Summary

This PR fixes the RSLIB benchmark setup after QoS adds `cases/*` to the cloned workspace. The RSLIB root uses `@rstest/adapter-rslib`, whose `@rslib/core` peer dependency can be re-resolved through stale registry metadata during `pnpm link ../scripts`; adding `@rslib/core: workspace:*` to the cloned RSLIB root keeps pnpm pinned to the local workspace package.

## Validation

- `corepack pnpm@8.15.9 --filter @modern-js/benchmark-scripts run build`